### PR TITLE
Fix: single digit hour files could not be parsed.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -80,7 +80,7 @@ export default class Parser {
 
   private tryComma(data: string) {
     data = data.replace(/\r/g, "");
-    var regex = /(\d+)\n(\d{2}:\d{2}:\d{2},\d{1,3}) --> (\d{2}:\d{2}:\d{2},\d{1,3})/g;
+    var regex = /(\d+)\n(\d{1,2}:\d{2}:\d{2},\d{1,3}) --> (\d{1,2}:\d{2}:\d{2},\d{1,3})/g;
     let data_array = data.split(regex);
     data_array.shift(); // remove first '' in array
     return data_array;
@@ -88,7 +88,7 @@ export default class Parser {
 
   private tryDot(data: string) {
     data = data.replace(/\r/g, "");
-    var regex = /(\d+)\n(\d{2}:\d{2}:\d{2}\.\d{1,3}) --> (\d{2}:\d{2}:\d{2}\.\d{1,3})/g;
+    var regex = /(\d+)\n(\d{1,2}:\d{2}:\d{2}\.\d{1,3}) --> (\d{1,2}:\d{2}:\d{2}\.\d{1,3})/g;
     let data_array = data.split(regex);
     data_array.shift(); // remove first '' in array
     this.seperator = ".";

--- a/test-file/single-digit-hour.srt
+++ b/test-file/single-digit-hour.srt
@@ -1,0 +1,11 @@
+﻿1
+0:00:03,120 --> 0:00:06,040
+Hi, I’m Carrie Anne, and welcome to Crash Course Computer Science!
+
+2
+0:00:06,040 --> 0:00:08,219
+We’re here: the final episode!
+
+3
+0:00:08,219 --> 0:00:12,080
+If you’ve watched the whole series, hopefully you’ve developed a newfound appreciation

--- a/test/wrong-format.ts
+++ b/test/wrong-format.ts
@@ -2,11 +2,12 @@ var { default: parser } = require("../src/index.js");
 var fs = require("fs");
 var chai = require("chai");
 
-var srt = fs.readFileSync("./test-file/dot-as-separator.srt", {
-  encoding: "utf-8"
-});
 
-describe("Test wrong srt", function() {
+describe("Test wrong format: dot as separator", function() {
+  var srt = fs.readFileSync("./test-file/dot-as-separator.srt", {
+    encoding: "utf-8"
+  });
+
   chai.should();
   var result: string[];
   var parser_instance = new parser();
@@ -17,6 +18,7 @@ describe("Test wrong srt", function() {
 
   it("parser.fromSrt() should return array", function() {
     chai.expect(result).to.be.a("array");
+    chai.expect(result).to.have.lengthOf(2);
   });
 
   it("parser.fromSrt() should contain valid subtitle objects", function() {
@@ -32,5 +34,38 @@ describe("Test wrong srt", function() {
   var originalData: string;
   it("parser.toSrt() should execute without crashes", function() {
     originalData = parser_instance.toSrt(result);
+  });
+});
+
+describe("Test wrong format: single digit hour", function() {
+  var srt = fs.readFileSync("./test-file/single-digit-hour.srt", {
+    encoding: "utf-8"
+  });
+
+  chai.should();
+  var result: string[];
+  var parser_instance = new parser();
+
+  it("parser.fromSrt() should execute without crashes", function() {
+    result = parser_instance.fromSrt(srt);
+  });
+
+  it("parser.fromSrt() should return array", function() {
+    chai.expect(result).to.be.a("array");
+    chai.expect(result).to.have.lengthOf(3);
+  });
+
+  it("parser.fromSrt() should contain valid subtitle objects", function() {
+    for (var i in result) {
+      var s = result[i];
+      chai.expect(s).to.have.property("id");
+      chai.expect(s).to.have.property("startTime");
+      chai.expect(s).to.have.property("endTime");
+      chai.expect(s).to.have.property("text");
+    }
+  });
+
+  it("parser.toSrt() should execute without crashes", function() {
+    var originalData = parser_instance.toSrt(result);
   });
 });


### PR DESCRIPTION
While the `correctFormat` function and the README suggested that this might parse srt files with timecodes in format `0:00:00,000` it did, in fact, not return anything.

This patch fixes that behaviour. A test and a demo file is included.

As an example: kdenlive currently produces `.srt` files formatted like in this example.