### PR TITLE
Add dist to npm publish

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -2,4 +2,3 @@ doc/
 example/
 test/
 test-file/
-dist/


### PR DESCRIPTION
The recent change to add CLI script requires the dist directory to be part of the npm package.

Running the command, `npx srt-parser-2 -i input.srt -o output.json --minify` right now throws an error,

```
node:internal/modules/cjs/loader:927
  throw err;
  ^

Error: Cannot find module '../dist/src/index'
Require stack:
- /Users/user/.npm/_npx/b731975f552886f1/node_modules/srt-parser-2/bin/index.js
    at Function.Module._resolveFilename (node:internal/modules/cjs/loader:924:15)
    at Function.Module._load (node:internal/modules/cjs/loader:769:27)
    at Module.require (node:internal/modules/cjs/loader:996:19)
    at require (node:internal/modules/cjs/helpers:92:18)
    at Object.<anonymous> (/Users/user/.npm/_npx/b731975f552886f1/node_modules/srt-parser-2/bin/index.js:6:31)
    at Module._compile (node:internal/modules/cjs/loader:1092:14)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1121:10)
    at Module.load (node:internal/modules/cjs/loader:972:32)
    at Function.Module._load (node:internal/modules/cjs/loader:813:14)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:76:12) {
  code: 'MODULE_NOT_FOUND',
  requireStack: [
    '/Users/user/.npm/_npx/b731975f552886f1/node_modules/srt-parser-2/bin/index.js'
  ]
}
```