### PR TITLE
Add type declarations in build step

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "version": "1.1.7",
     "license": "MIT",
     "scripts": {
-        "build": "tsc",
+        "build": "tsc --declaration",
         "dev": "tsc -watch",
         "test": "mocha ./dist/test --recursive"
     },


### PR DESCRIPTION
Fixes #10.

I think this is all that needs to be done. It worked for me locally, so I didn't need to include type definitions manually.