### PR TITLE
Fix CLI not working

### DIFF
--- a/bin/index.js
+++ b/bin/index.js
@@ -5,7 +5,7 @@ import { readFile, writeFile } from "fs/promises";
 
 import { hideBin } from "yargs/helpers";
 import path from "path";
-import srtParser2 from "../dist/src/index";
+import srtParser2 from "../dist/index.js";
 import yargs from "yargs/yargs";
 
 var argv = yargs(hideBin(process.argv)).argv;

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "description": "Parse SRT into array",
   "version": "1.2.2",
   "license": "MIT",
+  "type": "module",
   "scripts": {
     "build": "tsc --declaration",
     "dev": "tsc -watch",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,10 +11,10 @@
     // "disableReferencedProjectLoad": true,             /* Reduce the number of projects loaded automatically by TypeScript. */
 
     /* Language and Environment */
-    "target": "es2016",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
+    "target": "ES2022",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
     // "lib": [],                                        /* Specify a set of bundled library declaration files that describe the target runtime environment. */
     "lib": [
-      "es2017",
+      "ES2022",
       "dom",
       "scripthost"
     ],
@@ -30,7 +30,7 @@
     // "moduleDetection": "auto",                        /* Control what method is used to detect module-format JS files. */
 
     /* Modules */
-    "module": "commonjs",                                /* Specify what module code is generated. */
+    "module": "ES2022",                                /* Specify what module code is generated. */
     // "rootDir": "./",                                  /* Specify the root folder within your source files. */
     // "moduleResolution": "node",                       /* Specify how TypeScript looks up a file from a given module specifier. */
     // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */


### PR DESCRIPTION
This addresses #19 error.

Changes done:
Since the `bin/index.js` file is using modules (`import/export`), I updated `tsconfig.json` to stop using `commonjs`.
Also, the path to the generated JS file after TS compiling was wrong.

Everything seems to be working now. 