### PR TITLE
Fix support for single-digit timecodes

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -97,7 +97,7 @@ class Parser {
   private tryComma(data: string) {
     data = data.replace(/\r/g, "");
     var regex =
-      /(\d+)\n(\d{1,2}:\d{2}:\d{2},\d{1,3}) --> (\d{1,2}:\d{2}:\d{2},\d{1,3})/g;
+      /(\d+)\n(\d{1,2}:\d{1,2}:\d{1,2},\d{1,3}) --> (\d{1,2}:\d{1,2}:\d{1,2},\d{1,3})/g;
     let data_array = data.split(regex);
     data_array.shift(); // remove first '' in array
     return data_array;
@@ -106,7 +106,7 @@ class Parser {
   private tryDot(data: string) {
     data = data.replace(/\r/g, "");
     var regex =
-      /(\d+)\n(\d{1,2}:\d{2}:\d{2}\.\d{1,3}) --> (\d{1,2}:\d{2}:\d{2}\.\d{1,3})/g;
+      /(\d+)\n(\d{1,2}:\d{1,2}:\d{1,2}\.\d{1,3}) --> (\d{1,2}:\d{1,2}:\d{1,2}\.\d{1,3})/g;
     let data_array = data.split(regex);
     data_array.shift(); // remove first '' in array
     this.seperator = ".";

--- a/test-file/single-digit-timecodes.srt
+++ b/test-file/single-digit-timecodes.srt
@@ -1,0 +1,44 @@
+1
+0:0:7,560 --> 0:0:9,700
+- [Adam] Hello, my name is Adam Wilbert,
+
+2
+0:0:9,700 --> 0:0:10,520
+and I'd like to welcome you
+
+3
+0:0:10,840 --> 0:0:12,530
+to Learning Relational Databases.
+
+4
+0:0:12,530 --> 0:0:14,570
+In this course, I'm going
+to give you an overview
+
+5
+0:0:15,250 --> 0:0:18,540
+of the planning steps that
+you should move through
+
+6
+0:0:18,570 --> 0:0:21,350
+before you start development
+in order to ensure
+
+7
+0:0:21,360 --> 0:0:22,620
+that your system works as expected.
+
+8
+0:0:22,620 --> 0:0:24,830
+I'll start with an
+overview of what exactly
+
+9
+0:0:24,830 --> 0:0:27,490
+a relational database is and
+how its structure differs
+
+10
+0:0:27,530 --> 0:0:28,340
+from the spreadsheets

--- a/test/4. wrong-format.ts
+++ b/test/4. wrong-format.ts
@@ -68,3 +68,36 @@ describe("Test wrong format: single digit hour", function () {
     parser_instance.toSrt(result);
   });
 });
+
+describe("Test wrong format: single digit timecodes", function () {
+  var srt = fs.readFileSync("./test-file/single-digit-timecodes.srt", {
+    encoding: "utf-8",
+  });
+
+  chai.should();
+  var result: Line[];
+  var parser_instance = new parser();
+
+  it("parser.fromSrt() should execute without crashes", function () {
+    result = parser_instance.fromSrt(srt);
+  });
+
+  it("parser.fromSrt() should return array", function () {
+    chai.expect(result).to.be.a("array");
+    chai.expect(result).to.have.lengthOf(10);
+  });
+
+  it("parser.fromSrt() should contain valid subtitle objects", function () {
+    for (var i in result) {
+      var s = result[i];
+      chai.expect(s).to.have.property("id");
+      chai.expect(s).to.have.property("startTime");
+      chai.expect(s).to.have.property("endTime");
+      chai.expect(s).to.have.property("text");
+    }
+  });
+
+  it("parser.toSrt() should execute without crashes", function () {
+    parser_instance.toSrt(result);
+  });
+});


### PR DESCRIPTION
Hello and thank you for this library !

This PR fixes an issue I stumbled upon with a `srt` file having single-digit timecodes (see example file).

the `correctFormat` method does the job correctly but the regex being restrictive prevents it from performing it's duty correctly.

This fix addresses that. All previous tests pass, and I added one for this case.